### PR TITLE
Add generic system tool detection with MVX_USE_SYSTEM_* environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,74 @@ mvx automatically detects the configuration format:
 - Simplified CI/CD setup
 - Better collaboration with consistent tooling
 
+## 🚀 CI/CD Integration
+
+mvx is designed to work seamlessly in CI/CD environments. For faster builds and better reliability, you can configure mvx to use pre-installed tools instead of downloading them.
+
+### Using System Tools in CI
+
+When running in CI environments like GitHub Actions, the runners often have tools like Java and Maven pre-installed. You can configure mvx to use system tools instead of downloading them:
+
+```bash
+# Use system Java
+export MVX_USE_SYSTEM_JAVA=true
+
+# Use system Maven
+export MVX_USE_SYSTEM_MAVEN=true
+
+# Use system Node.js (when implemented)
+export MVX_USE_SYSTEM_NODE=true
+
+./mvx setup
+./mvx build
+```
+
+**Supported Tools:**
+- ✅ **Java**: Uses `JAVA_HOME` environment variable
+- ✅ **Maven**: Uses `MAVEN_HOME`, `M2_HOME`, or finds `mvn` in PATH
+- 🚧 **Node.js**: Coming soon
+- 🚧 **Go**: Coming soon
+
+**Benefits:**
+- ⚡ **Faster builds**: No time spent downloading tools
+- 🛡️ **More reliable**: Avoids network/download issues
+- 💾 **Better resource usage**: Uses existing installations
+- 🎯 **Selective control**: Enable/disable per tool independently
+
+**Example GitHub Actions workflow:**
+
+```yaml
+name: Build
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Maven
+        uses: actions/setup-maven@v4
+        with:
+          maven-version: '3.9.6'
+
+      - name: Build with mvx
+        env:
+          MVX_USE_SYSTEM_JAVA: true
+          MVX_USE_SYSTEM_MAVEN: true
+        run: |
+          ./mvx setup
+          ./mvx build
+```
+
+This approach works with any CI system that provides Java pre-installed or allows you to install it separately.
+
 ## 💡 Example Configuration
 
 mvx supports both **JSON5** and **YAML** configuration formats, inspired by [Maven Mason](https://github.com/maveniverse/mason).

--- a/pkg/tools/java_test.go
+++ b/pkg/tools/java_test.go
@@ -1,0 +1,211 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/gnodet/mvx/pkg/config"
+)
+
+func TestUseSystemTool(t *testing.T) {
+	// Test when MVX_USE_SYSTEM_JAVA is not set
+	os.Unsetenv("MVX_USE_SYSTEM_JAVA")
+	if useSystemTool("java") {
+		t.Error("useSystemTool('java') should return false when MVX_USE_SYSTEM_JAVA is not set")
+	}
+
+	// Test when MVX_USE_SYSTEM_JAVA is set to false
+	os.Setenv("MVX_USE_SYSTEM_JAVA", "false")
+	if useSystemTool("java") {
+		t.Error("useSystemTool('java') should return false when MVX_USE_SYSTEM_JAVA=false")
+	}
+
+	// Test when MVX_USE_SYSTEM_JAVA is set to true
+	os.Setenv("MVX_USE_SYSTEM_JAVA", "true")
+	if !useSystemTool("java") {
+		t.Error("useSystemTool('java') should return true when MVX_USE_SYSTEM_JAVA=true")
+	}
+
+	// Test Maven tool
+	os.Unsetenv("MVX_USE_SYSTEM_MAVEN")
+	if useSystemTool("maven") {
+		t.Error("useSystemTool('maven') should return false when MVX_USE_SYSTEM_MAVEN is not set")
+	}
+
+	os.Setenv("MVX_USE_SYSTEM_MAVEN", "true")
+	if !useSystemTool("maven") {
+		t.Error("useSystemTool('maven') should return true when MVX_USE_SYSTEM_MAVEN=true")
+	}
+
+	// Clean up
+	os.Unsetenv("MVX_USE_SYSTEM_JAVA")
+	os.Unsetenv("MVX_USE_SYSTEM_MAVEN")
+}
+
+func TestUseSystemJava(t *testing.T) {
+	// Test when MVX_USE_SYSTEM_JAVA is not set
+	os.Unsetenv("MVX_USE_SYSTEM_JAVA")
+	if useSystemJava() {
+		t.Error("useSystemJava() should return false when MVX_USE_SYSTEM_JAVA is not set")
+	}
+
+	// Test when MVX_USE_SYSTEM_JAVA is set to false
+	os.Setenv("MVX_USE_SYSTEM_JAVA", "false")
+	if useSystemJava() {
+		t.Error("useSystemJava() should return false when MVX_USE_SYSTEM_JAVA=false")
+	}
+
+	// Test when MVX_USE_SYSTEM_JAVA is set to true
+	os.Setenv("MVX_USE_SYSTEM_JAVA", "true")
+	if !useSystemJava() {
+		t.Error("useSystemJava() should return true when MVX_USE_SYSTEM_JAVA=true")
+	}
+
+	// Clean up
+	os.Unsetenv("MVX_USE_SYSTEM_JAVA")
+}
+
+func TestJavaSystemDetector(t *testing.T) {
+	detector := &JavaSystemDetector{}
+
+	// Save original JAVA_HOME
+	originalJavaHome := os.Getenv("JAVA_HOME")
+	defer func() {
+		if originalJavaHome != "" {
+			os.Setenv("JAVA_HOME", originalJavaHome)
+		} else {
+			os.Unsetenv("JAVA_HOME")
+		}
+	}()
+
+	// Test when JAVA_HOME is not set
+	os.Unsetenv("JAVA_HOME")
+	_, err := detector.GetSystemHome()
+	if err == nil {
+		t.Error("GetSystemHome() should return error when JAVA_HOME is not set")
+	}
+
+	// Test when JAVA_HOME points to non-existent directory
+	os.Setenv("JAVA_HOME", "/non/existent/path")
+	_, err = detector.GetSystemHome()
+	if err == nil {
+		t.Error("GetSystemHome() should return error when JAVA_HOME points to non-existent directory")
+	}
+}
+
+func TestJavaSystemDetectorVersion(t *testing.T) {
+	detector := &JavaSystemDetector{}
+
+	// This test requires a real Java installation, so we'll skip it if JAVA_HOME is not set
+	javaHome := os.Getenv("JAVA_HOME")
+	if javaHome == "" {
+		t.Skip("Skipping test because JAVA_HOME is not set")
+	}
+
+	// Check if Java executable exists
+	javaExe := filepath.Join(javaHome, "bin", "java")
+	if runtime.GOOS == "windows" {
+		javaExe += ".exe"
+	}
+
+	if _, err := os.Stat(javaExe); err != nil {
+		t.Skip("Skipping test because Java executable not found at JAVA_HOME")
+	}
+
+	version, err := detector.GetSystemVersion(javaHome)
+	if err != nil {
+		t.Errorf("GetSystemVersion() failed: %v", err)
+	}
+
+	if version == "" {
+		t.Error("GetSystemVersion() returned empty version")
+	}
+
+	t.Logf("Detected Java version: %s", version)
+}
+
+func TestJavaVersionCompatibility(t *testing.T) {
+	detector := &JavaSystemDetector{}
+
+	tests := []struct {
+		systemVersion    string
+		requestedVersion string
+		expected         bool
+	}{
+		{"21", "21", true},
+		{"17", "17", true},
+		{"11", "11", true},
+		{"8", "8", true},
+		{"21", "17", false},
+		{"17", "21", false},
+		{"11", "8", false},
+	}
+
+	for _, test := range tests {
+		result := detector.IsVersionCompatible(test.systemVersion, test.requestedVersion)
+		if result != test.expected {
+			t.Errorf("IsVersionCompatible(%s, %s) = %v, expected %v",
+				test.systemVersion, test.requestedVersion, result, test.expected)
+		}
+	}
+}
+
+func TestJavaToolWithSystemJava(t *testing.T) {
+	// Save original environment variables
+	originalUseSystemJava := os.Getenv("MVX_USE_SYSTEM_JAVA")
+	originalJavaHome := os.Getenv("JAVA_HOME")
+	defer func() {
+		if originalUseSystemJava != "" {
+			os.Setenv("MVX_USE_SYSTEM_JAVA", originalUseSystemJava)
+		} else {
+			os.Unsetenv("MVX_USE_SYSTEM_JAVA")
+		}
+		if originalJavaHome != "" {
+			os.Setenv("JAVA_HOME", originalJavaHome)
+		} else {
+			os.Unsetenv("JAVA_HOME")
+		}
+	}()
+
+	// Create a mock manager
+	manager, err := NewManager()
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	javaTool := &JavaTool{manager: manager}
+
+	// Test with MVX_USE_SYSTEM_JAVA=false (default behavior)
+	os.Unsetenv("MVX_USE_SYSTEM_JAVA")
+	os.Unsetenv("JAVA_HOME")
+
+	cfg := config.ToolConfig{
+		Version:      "11", // Use version 11 which won't be installed
+		Distribution: "temurin",
+	}
+
+	// IsInstalled should return false when no Java is installed and MVX_USE_SYSTEM_JAVA is not set
+	if javaTool.IsInstalled("11", cfg) {
+		t.Error("IsInstalled should return false when no Java is installed")
+	}
+
+	// Test with MVX_USE_SYSTEM_JAVA=true but no JAVA_HOME
+	os.Setenv("MVX_USE_SYSTEM_JAVA", "true")
+	os.Unsetenv("JAVA_HOME")
+
+	// IsInstalled should still return false when JAVA_HOME is not set
+	if javaTool.IsInstalled("11", cfg) {
+		t.Error("IsInstalled should return false when MVX_USE_SYSTEM_JAVA=true but JAVA_HOME is not set")
+	}
+
+	// Test with MVX_USE_SYSTEM_JAVA=true and JAVA_HOME set but version mismatch
+	os.Setenv("MVX_USE_SYSTEM_JAVA", "true")
+	os.Setenv("JAVA_HOME", "/usr/lib/jvm/java-21-openjdk-amd64")
+
+	// IsInstalled should return false when system Java version doesn't match
+	if javaTool.IsInstalled("11", cfg) {
+		t.Error("IsInstalled should return false when system Java version doesn't match requested version")
+	}
+}

--- a/pkg/tools/maven.go
+++ b/pkg/tools/maven.go
@@ -25,9 +25,44 @@ func (m *MavenTool) Name() string {
 	return "maven"
 }
 
+// useSystemMaven checks if system Maven should be used instead of downloading
+func useSystemMaven() bool {
+	return useSystemTool("maven")
+}
+
+// getSystemMavenDetector returns a system detector for Maven
+func getSystemMavenDetector() SystemToolDetector {
+	return &MavenSystemDetector{}
+}
+
 // Install downloads and installs the specified Maven version
 func (m *MavenTool) Install(version string, cfg config.ToolConfig) error {
 	installDir := m.manager.GetToolVersionDir("maven", version, "")
+
+	// Check if we should use system Maven instead of downloading
+	if useSystemMaven() {
+		logVerbose("%s=true, attempting to use system Maven", getSystemToolEnvVar("maven"))
+
+		detector := getSystemMavenDetector()
+		systemMavenHome, err := detector.GetSystemHome()
+		if err != nil {
+			logVerbose("System Maven not available: %v", err)
+			fmt.Printf("  ⚠️  System Maven not available (%v), falling back to download\n", err)
+		} else {
+			systemVersion, err := detector.GetSystemVersion(systemMavenHome)
+			if err != nil {
+				logVerbose("Could not determine system Maven version: %v", err)
+				fmt.Printf("  ⚠️  Could not determine system Maven version (%v), falling back to download\n", err)
+			} else if !detector.IsVersionCompatible(systemVersion, version) {
+				logVerbose("System Maven version %s does not match requested version %s", systemVersion, version)
+				fmt.Printf("  ⚠️  System Maven version %s does not match requested version %s, falling back to download\n", systemVersion, version)
+			} else {
+				// Use system Maven by creating a symlink
+				fmt.Printf("  🔗 Using system Maven %s from %s\n", systemVersion, systemMavenHome)
+				return detector.CreateSystemLink(systemMavenHome, installDir)
+			}
+		}
+	}
 
 	// Create installation directory
 	if err := os.MkdirAll(installDir, 0755); err != nil {
@@ -48,6 +83,20 @@ func (m *MavenTool) Install(version string, cfg config.ToolConfig) error {
 
 // IsInstalled checks if the specified version is installed
 func (m *MavenTool) IsInstalled(version string, cfg config.ToolConfig) bool {
+	// If using system Maven, check if system Maven is available and compatible
+	if useSystemMaven() {
+		detector := getSystemMavenDetector()
+		if systemMavenHome, err := detector.GetSystemHome(); err == nil {
+			if systemVersion, err := detector.GetSystemVersion(systemMavenHome); err == nil {
+				if detector.IsVersionCompatible(systemVersion, version) {
+					logVerbose("System Maven %s is available and compatible with requested version %s", systemVersion, version)
+					return true
+				}
+			}
+		}
+		// If system Maven is not available or compatible, fall through to check downloaded version
+	}
+
 	installDir := m.manager.GetToolVersionDir("maven", version, "")
 	mvnExe := filepath.Join(installDir, "bin", "mvn")
 	if runtime.GOOS == "windows" {
@@ -60,6 +109,20 @@ func (m *MavenTool) IsInstalled(version string, cfg config.ToolConfig) bool {
 
 // GetPath returns the installation path for the specified version
 func (m *MavenTool) GetPath(version string, cfg config.ToolConfig) (string, error) {
+	// If using system Maven, return system Maven home if available and compatible
+	if useSystemMaven() {
+		detector := getSystemMavenDetector()
+		if systemMavenHome, err := detector.GetSystemHome(); err == nil {
+			if systemVersion, err := detector.GetSystemVersion(systemMavenHome); err == nil {
+				if detector.IsVersionCompatible(systemVersion, version) {
+					logVerbose("Using system Maven %s from %s", systemVersion, systemMavenHome)
+					return systemMavenHome, nil
+				}
+			}
+		}
+		// If system Maven is not available or compatible, fall through to check downloaded version
+	}
+
 	installDir := m.manager.GetToolVersionDir("maven", version, "")
 
 	// Maven archives typically extract to apache-maven-{version}/

--- a/pkg/tools/maven_test.go
+++ b/pkg/tools/maven_test.go
@@ -1,0 +1,102 @@
+package tools
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gnodet/mvx/pkg/config"
+)
+
+func TestUseSystemMaven(t *testing.T) {
+	// Test when MVX_USE_SYSTEM_MAVEN is not set
+	os.Unsetenv("MVX_USE_SYSTEM_MAVEN")
+	if useSystemMaven() {
+		t.Error("useSystemMaven() should return false when MVX_USE_SYSTEM_MAVEN is not set")
+	}
+
+	// Test when MVX_USE_SYSTEM_MAVEN is set to false
+	os.Setenv("MVX_USE_SYSTEM_MAVEN", "false")
+	if useSystemMaven() {
+		t.Error("useSystemMaven() should return false when MVX_USE_SYSTEM_MAVEN=false")
+	}
+
+	// Test when MVX_USE_SYSTEM_MAVEN is set to true
+	os.Setenv("MVX_USE_SYSTEM_MAVEN", "true")
+	if !useSystemMaven() {
+		t.Error("useSystemMaven() should return true when MVX_USE_SYSTEM_MAVEN=true")
+	}
+
+	// Clean up
+	os.Unsetenv("MVX_USE_SYSTEM_MAVEN")
+}
+
+func TestMavenSystemDetector(t *testing.T) {
+	detector := &MavenSystemDetector{}
+
+	// Test GetSystemHome when no Maven environment variables are set
+	os.Unsetenv("MAVEN_HOME")
+	os.Unsetenv("M2_HOME")
+
+	_, err := detector.GetSystemHome()
+	// This might succeed if mvn is in PATH, so we don't assert failure
+	if err != nil {
+		t.Logf("Maven not found in system (expected): %v", err)
+	}
+}
+
+func TestMavenToolWithSystemMaven(t *testing.T) {
+	// Save original environment variables
+	originalUseSystemMaven := os.Getenv("MVX_USE_SYSTEM_MAVEN")
+	originalMavenHome := os.Getenv("MAVEN_HOME")
+	originalM2Home := os.Getenv("M2_HOME")
+	defer func() {
+		if originalUseSystemMaven != "" {
+			os.Setenv("MVX_USE_SYSTEM_MAVEN", originalUseSystemMaven)
+		} else {
+			os.Unsetenv("MVX_USE_SYSTEM_MAVEN")
+		}
+		if originalMavenHome != "" {
+			os.Setenv("MAVEN_HOME", originalMavenHome)
+		} else {
+			os.Unsetenv("MAVEN_HOME")
+		}
+		if originalM2Home != "" {
+			os.Setenv("M2_HOME", originalM2Home)
+		} else {
+			os.Unsetenv("M2_HOME")
+		}
+	}()
+
+	// Create a mock manager
+	manager, err := NewManager()
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	mavenTool := &MavenTool{manager: manager}
+
+	// Test with MVX_USE_SYSTEM_MAVEN=false (default behavior)
+	os.Unsetenv("MVX_USE_SYSTEM_MAVEN")
+	os.Unsetenv("MAVEN_HOME")
+	os.Unsetenv("M2_HOME")
+
+	cfg := config.ToolConfig{
+		Version: "3.9.6",
+	}
+
+	// IsInstalled should return false when no Maven is installed and MVX_USE_SYSTEM_MAVEN is not set
+	if mavenTool.IsInstalled("3.9.6", cfg) {
+		t.Error("IsInstalled should return false when no Maven is installed")
+	}
+
+	// Test with MVX_USE_SYSTEM_MAVEN=true but no MAVEN_HOME or M2_HOME
+	os.Setenv("MVX_USE_SYSTEM_MAVEN", "true")
+	os.Unsetenv("MAVEN_HOME")
+	os.Unsetenv("M2_HOME")
+
+	// IsInstalled should return false when Maven environment variables are not set
+	// (unless mvn is found in PATH with a compatible version)
+	if mavenTool.IsInstalled("3.9.6", cfg) {
+		t.Log("Maven found in PATH with compatible version")
+	}
+}

--- a/pkg/tools/system.go
+++ b/pkg/tools/system.go
@@ -1,0 +1,267 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// useSystemTool checks if a system tool should be used instead of downloading
+// by checking the MVX_USE_SYSTEM_<TOOL> environment variable
+func useSystemTool(toolName string) bool {
+	envVar := fmt.Sprintf("MVX_USE_SYSTEM_%s", strings.ToUpper(toolName))
+	return os.Getenv(envVar) == "true"
+}
+
+// getSystemToolEnvVar returns the environment variable name for a tool
+func getSystemToolEnvVar(toolName string) string {
+	return fmt.Sprintf("MVX_USE_SYSTEM_%s", strings.ToUpper(toolName))
+}
+
+// SystemToolDetector provides methods for detecting and validating system tools
+type SystemToolDetector interface {
+	// GetSystemHome returns the system installation path for the tool
+	GetSystemHome() (string, error)
+
+	// GetSystemVersion returns the version of the system tool
+	GetSystemVersion(toolHome string) (string, error)
+
+	// IsVersionCompatible checks if the system version is compatible with requested version
+	IsVersionCompatible(systemVersion, requestedVersion string) bool
+
+	// CreateSystemLink creates a symlink to the system tool installation
+	CreateSystemLink(systemHome, installDir string) error
+}
+
+// JavaSystemDetector implements SystemToolDetector for Java
+type JavaSystemDetector struct{}
+
+// GetSystemHome returns the system JAVA_HOME if available and valid
+func (d *JavaSystemDetector) GetSystemHome() (string, error) {
+	javaHome := os.Getenv("JAVA_HOME")
+	if javaHome == "" {
+		return "", fmt.Errorf("JAVA_HOME environment variable not set")
+	}
+
+	// Check if JAVA_HOME points to a valid Java installation
+	javaExe := filepath.Join(javaHome, "bin", "java")
+	if runtime.GOOS == "windows" {
+		javaExe += ".exe"
+	}
+
+	if _, err := os.Stat(javaExe); err != nil {
+		return "", fmt.Errorf("Java executable not found at %s", javaExe)
+	}
+
+	return javaHome, nil
+}
+
+// GetSystemVersion returns the version of the system Java installation
+func (d *JavaSystemDetector) GetSystemVersion(javaHome string) (string, error) {
+	javaExe := filepath.Join(javaHome, "bin", "java")
+	if runtime.GOOS == "windows" {
+		javaExe += ".exe"
+	}
+
+	cmd := exec.Command(javaExe, "-version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to get Java version: %w", err)
+	}
+
+	// Parse version from output (e.g., "openjdk version "21.0.1" 2023-10-17")
+	outputStr := string(output)
+	lines := strings.Split(outputStr, "\n")
+	if len(lines) == 0 {
+		return "", fmt.Errorf("no version output from Java")
+	}
+
+	// Look for version pattern in first line
+	versionLine := lines[0]
+	// Extract version number (handles both old and new format)
+	if strings.Contains(versionLine, "\"") {
+		start := strings.Index(versionLine, "\"")
+		if start != -1 {
+			end := strings.Index(versionLine[start+1:], "\"")
+			if end != -1 {
+				version := versionLine[start+1 : start+1+end]
+				// Extract major version (e.g., "21.0.1" -> "21", "1.8.0_391" -> "8")
+				if strings.HasPrefix(version, "1.") {
+					// Old format (Java 8 and below): "1.8.0_391" -> "8"
+					parts := strings.Split(version, ".")
+					if len(parts) >= 2 {
+						return parts[1], nil
+					}
+				} else {
+					// New format (Java 9+): "21.0.1" -> "21"
+					parts := strings.Split(version, ".")
+					if len(parts) >= 1 {
+						return parts[0], nil
+					}
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("could not parse Java version from: %s", versionLine)
+}
+
+// IsVersionCompatible checks if the system Java version is compatible with the requested version
+func (d *JavaSystemDetector) IsVersionCompatible(systemVersion, requestedVersion string) bool {
+	// For now, we require exact major version match
+	// This could be made more flexible in the future
+	return systemVersion == requestedVersion
+}
+
+// CreateSystemLink creates a symlink to the system Java installation
+func (d *JavaSystemDetector) CreateSystemLink(systemHome, installDir string) error {
+	// Create installation directory
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		return fmt.Errorf("failed to create installation directory: %w", err)
+	}
+
+	// Create a symlink to the system Java
+	linkPath := filepath.Join(installDir, "jdk")
+
+	// Remove existing link/directory if it exists
+	if _, err := os.Lstat(linkPath); err == nil {
+		if err := os.RemoveAll(linkPath); err != nil {
+			return fmt.Errorf("failed to remove existing installation: %w", err)
+		}
+	}
+
+	// Create symlink
+	if err := os.Symlink(systemHome, linkPath); err != nil {
+		return fmt.Errorf("failed to create symlink to system tool: %w", err)
+	}
+
+	logVerbose("Created symlink from %s to %s", linkPath, systemHome)
+	return nil
+}
+
+// MavenSystemDetector implements SystemToolDetector for Maven
+type MavenSystemDetector struct{}
+
+// GetSystemHome returns the system MAVEN_HOME if available and valid
+func (d *MavenSystemDetector) GetSystemHome() (string, error) {
+	// Try MAVEN_HOME first
+	mavenHome := os.Getenv("MAVEN_HOME")
+	if mavenHome != "" {
+		mvnExe := filepath.Join(mavenHome, "bin", "mvn")
+		if runtime.GOOS == "windows" {
+			mvnExe += ".cmd"
+		}
+		if _, err := os.Stat(mvnExe); err == nil {
+			return mavenHome, nil
+		}
+	}
+
+	// Try M2_HOME as fallback
+	m2Home := os.Getenv("M2_HOME")
+	if m2Home != "" {
+		mvnExe := filepath.Join(m2Home, "bin", "mvn")
+		if runtime.GOOS == "windows" {
+			mvnExe += ".cmd"
+		}
+		if _, err := os.Stat(mvnExe); err == nil {
+			return m2Home, nil
+		}
+	}
+
+	// Try to find mvn in PATH
+	mvnExe := "mvn"
+	if runtime.GOOS == "windows" {
+		mvnExe = "mvn.cmd"
+	}
+
+	if mvnPath, err := exec.LookPath(mvnExe); err == nil {
+		// Try to determine MAVEN_HOME from mvn path
+		// mvn is typically at $MAVEN_HOME/bin/mvn
+		binDir := filepath.Dir(mvnPath)
+		mavenHome := filepath.Dir(binDir)
+
+		// Verify this looks like a Maven installation
+		if _, err := os.Stat(filepath.Join(mavenHome, "lib")); err == nil {
+			return mavenHome, nil
+		}
+	}
+
+	return "", fmt.Errorf("Maven not found in MAVEN_HOME, M2_HOME, or PATH")
+}
+
+// GetSystemVersion returns the version of the system Maven installation
+func (d *MavenSystemDetector) GetSystemVersion(mavenHome string) (string, error) {
+	mvnExe := filepath.Join(mavenHome, "bin", "mvn")
+	if runtime.GOOS == "windows" {
+		mvnExe += ".cmd"
+	}
+
+	cmd := exec.Command(mvnExe, "--version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to get Maven version: %w", err)
+	}
+
+	// Parse version from output (e.g., "Apache Maven 3.9.6 (bc0240f3c744dd6b6ec2920b3cd08dcc295161ae)")
+	outputStr := string(output)
+	lines := strings.Split(outputStr, "\n")
+	if len(lines) == 0 {
+		return "", fmt.Errorf("no version output from Maven")
+	}
+
+	// Look for "Apache Maven" in the first line
+	versionLine := lines[0]
+	if strings.Contains(versionLine, "Apache Maven") {
+		parts := strings.Fields(versionLine)
+		if len(parts) >= 3 {
+			version := parts[2]
+			// Remove ANSI escape sequences (e.g., "3.6.3\x1b[m" -> "3.6.3")
+			ansiRegex := regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+			version = ansiRegex.ReplaceAllString(version, "")
+			// Also remove any remaining bracket sequences
+			if idx := strings.Index(version, "["); idx != -1 {
+				version = version[:idx]
+			}
+			return version, nil // "Apache Maven 3.9.6" -> "3.9.6"
+		}
+	}
+
+	return "", fmt.Errorf("could not parse Maven version from: %s", versionLine)
+}
+
+// IsVersionCompatible checks if the system Maven version is compatible with the requested version
+func (d *MavenSystemDetector) IsVersionCompatible(systemVersion, requestedVersion string) bool {
+	// For Maven, we can be more flexible - allow compatible versions
+	// For now, exact match, but this could be enhanced to support semantic versioning
+	return systemVersion == requestedVersion
+}
+
+// CreateSystemLink creates a symlink to the system Maven installation
+func (d *MavenSystemDetector) CreateSystemLink(systemHome, installDir string) error {
+	// Create installation directory
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		return fmt.Errorf("failed to create installation directory: %w", err)
+	}
+
+	// For Maven, we typically create a direct symlink to the Maven home
+	linkPath := filepath.Join(installDir, "maven")
+
+	// Remove existing link/directory if it exists
+	if _, err := os.Lstat(linkPath); err == nil {
+		if err := os.RemoveAll(linkPath); err != nil {
+			return fmt.Errorf("failed to remove existing installation: %w", err)
+		}
+	}
+
+	// Create symlink
+	if err := os.Symlink(systemHome, linkPath); err != nil {
+		return fmt.Errorf("failed to create symlink to system tool: %w", err)
+	}
+
+	logVerbose("Created symlink from %s to %s", linkPath, systemHome)
+	return nil
+}

--- a/website/content/tools.md
+++ b/website/content/tools.md
@@ -35,6 +35,33 @@ mvx tools add go 1.23.1
 - ✅ **Preserves** existing configuration and formatting
 - ✅ **Adds comments** and proper JSON5 structure
 
+## Using System Tools
+
+For CI environments, corporate setups, or when you prefer to use existing tool installations, mvx supports using system-installed tools instead of downloading them. This is controlled via environment variables:
+
+```bash
+# Enable system tools individually
+export MVX_USE_SYSTEM_JAVA=true
+export MVX_USE_SYSTEM_MAVEN=true
+export MVX_USE_SYSTEM_NODE=true    # Coming soon
+export MVX_USE_SYSTEM_GO=true      # Coming soon
+
+./mvx setup
+```
+
+**Benefits:**
+- ⚡ **Faster builds**: No download time
+- 🛡️ **More reliable**: Avoids network issues
+- 💾 **Better resource usage**: Uses existing installations
+- 🎯 **Selective control**: Enable per tool independently
+- 🔒 **Security**: Use centrally managed, approved tool versions
+
+**How it works:**
+1. When `MVX_USE_SYSTEM_<TOOL>=true` is set, mvx first tries to use the system installation
+2. Validates that the system tool version matches your configuration
+3. If compatible, creates a symlink to integrate with mvx's tool management
+4. If incompatible or unavailable, falls back to downloading
+
 ## Supported Tools
 
 ## Java Ecosystem
@@ -53,6 +80,34 @@ Automatic installation of OpenJDK distributions.
     }
   }
 }
+```
+
+#### Using System Java
+
+For CI environments or when you prefer to use an existing Java installation, you can configure mvx to use the system Java instead of downloading:
+
+```bash
+export MVX_USE_SYSTEM_JAVA=true
+export JAVA_HOME=/path/to/your/java
+./mvx build
+```
+
+When `MVX_USE_SYSTEM_JAVA=true` is set:
+
+- ✅ **Uses existing Java**: mvx will use the Java installation from `JAVA_HOME`
+- ✅ **Version validation**: Ensures the system Java version matches the requested version
+- ✅ **Faster setup**: No time spent downloading Java in CI environments
+- ✅ **Fallback behavior**: If system Java is unavailable or incompatible, falls back to downloading
+
+**Requirements:**
+- `JAVA_HOME` environment variable must be set
+- System Java version must match the major version specified in your configuration
+- Java executable must be available at `$JAVA_HOME/bin/java`
+
+**Use Cases:**
+- **GitHub Actions**: Runners have Java pre-installed
+- **Corporate environments**: Java is centrally managed
+- **Offline environments**: Where downloading is restricted
 ```
 
 **Supported Versions**: 8, 11, 17, 21, 22, 23  
@@ -74,8 +129,34 @@ Apache Maven build automation tool.
 }
 ```
 
-**Supported Versions**: 3.6.x, 3.8.x, 3.9.x  
+**Supported Versions**: 3.6.x, 3.8.x, 3.9.x
 **Platforms**: All (Java-based)
+
+#### Using System Maven
+
+For CI environments or when you prefer to use an existing Maven installation:
+
+```bash
+export MVX_USE_SYSTEM_MAVEN=true
+./mvx build
+```
+
+When `MVX_USE_SYSTEM_MAVEN=true` is set:
+
+- ✅ **Uses existing Maven**: mvx will use Maven from `MAVEN_HOME`, `M2_HOME`, or PATH
+- ✅ **Version validation**: Ensures the system Maven version matches the requested version
+- ✅ **Faster setup**: No time spent downloading Maven in CI environments
+- ✅ **Fallback behavior**: If system Maven is unavailable or incompatible, falls back to downloading
+
+**Detection Order:**
+1. `MAVEN_HOME` environment variable
+2. `M2_HOME` environment variable (fallback)
+3. `mvn` command in PATH
+
+**Requirements:**
+- Maven must be accessible via one of the detection methods above
+- System Maven version must match the version specified in your configuration
+- Maven executable must be functional (`mvn --version` works)
 
 ### Maven Daemon
 


### PR DESCRIPTION
## Summary

Implements a **generic system tool detection mechanism** that allows using pre-installed tools instead of downloading them. This addresses issue #2 with a scalable solution that works for multiple tools.

## Changes

### 🔧 Generic System Tool Framework
- **Generic `useSystemTool(toolName)` function** - works for any tool
- **`SystemToolDetector` interface** - consistent detection pattern
- **Individual environment variables** - `MVX_USE_SYSTEM_JAVA`, `MVX_USE_SYSTEM_MAVEN`, etc.
- **Extensible design** - easy to add support for Node.js, Go, etc.

### ✅ Supported Tools

#### Java (`MVX_USE_SYSTEM_JAVA=true`)
- **Detection**: Uses `JAVA_HOME` environment variable
- **Version parsing**: Handles both old (1.8.x) and new (21.x) format
- **Validation**: Ensures system Java version matches requested version
- **Integration**: Creates symlink for seamless mvx integration

#### Maven (`MVX_USE_SYSTEM_MAVEN=true`)
- **Detection**: Tries `MAVEN_HOME`, `M2_HOME`, then `mvn` in PATH
- **Version parsing**: Handles ANSI color codes in output
- **Validation**: Ensures system Maven version matches requested version
- **Integration**: Creates symlink for seamless mvx integration

### 🧪 Testing
- **Comprehensive unit tests** for both Java and Maven
- **Generic tool detection tests**
- **Version compatibility tests**
- **System integration tests**
- **All existing tests pass** - no breaking changes

### 📚 Documentation
- **Updated README.md** with multi-tool CI examples
- **Updated website/content/tools.md** with detailed usage for each tool
- **Added generic system tools section**
- **GitHub Actions examples** showing multiple tools

## Usage

### Individual Tool Control
```bash
# Use system Java only
export MVX_USE_SYSTEM_JAVA=true
export JAVA_HOME=/path/to/java

# Use system Maven only  
export MVX_USE_SYSTEM_MAVEN=true

# Use both
export MVX_USE_SYSTEM_JAVA=true
export MVX_USE_SYSTEM_MAVEN=true

./mvx setup
./mvx build
```

### GitHub Actions Example
```yaml
name: Build
on: [push, pull_request]

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      
      - name: Set up JDK 21
        uses: actions/setup-java@v4
        with:
          java-version: '21'
          distribution: 'temurin'
      
      - name: Set up Maven
        uses: actions/setup-maven@v4
        with:
          maven-version: '3.9.6'
      
      - name: Build with mvx
        env:
          MVX_USE_SYSTEM_JAVA: true
          MVX_USE_SYSTEM_MAVEN: true
        run: |
          ./mvx setup
          ./mvx build
```

## Benefits

✅ **Selective control** - Enable/disable per tool independently  
✅ **Faster CI builds** - No time spent downloading tools  
✅ **More reliable** - Avoids network/download issues  
✅ **Better resource usage** - Uses existing installations  
✅ **Backward compatible** - Existing behavior unchanged  
✅ **Extensible** - Easy to add more tools  
✅ **Robust fallback** - Downloads when system tools unavailable  

## Future Extensions

This framework makes it easy to add system tool detection for:
- 🚧 **Node.js** (`MVX_USE_SYSTEM_NODE=true`)
- 🚧 **Go** (`MVX_USE_SYSTEM_GO=true`) 
- 🚧 **Python** (`MVX_USE_SYSTEM_PYTHON=true`)
- 🚧 **Any other tool** following the same pattern

## Testing Results

Tested with:
- ✅ Java 21 system installation (compatible)
- ✅ Maven 3.6.3 system installation (compatible)
- ✅ Version mismatch scenarios (falls back to download)
- ✅ Missing system tools (falls back to download)
- ✅ Environment variables not set (existing behavior)
- ✅ Multiple tools enabled simultaneously
- ✅ All unit and integration tests pass

Closes #2