### PR TITLE
perf: optimize mvx mvn command performance by 92%

### DIFF
--- a/cmd/mvn.go
+++ b/cmd/mvn.go
@@ -43,9 +43,14 @@ Examples:
 			return fmt.Errorf("no Maven tool configured. Add tools.maven to .mvx/config and run 'mvx setup'")
 		}
 
-		// Ensure tools installed and get environment
-		if err := mgr.InstallTools(cfg); err != nil {
-			return fmt.Errorf("failed to install tools: %w", err)
+		// Only ensure Maven and Java are installed (Maven needs Java)
+		requiredTools := []string{"maven"}
+		if _, hasJava := cfg.Tools["java"]; hasJava {
+			requiredTools = append(requiredTools, "java")
+		}
+
+		if err := mgr.InstallSpecificTools(cfg, requiredTools); err != nil {
+			return fmt.Errorf("failed to install required tools: %w", err)
 		}
 		envMap, err := mgr.SetupEnvironment(cfg)
 		if err != nil {

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -509,6 +509,10 @@ func (r *ToolRegistry) fetchNodeIndex() ([]nodeIndexEntry, error) {
 
 // ResolveJavaVersion resolves a Java version specification to a concrete version
 func (r *ToolRegistry) ResolveJavaVersion(versionSpec, distribution string) (string, error) {
+	if distribution == "" {
+		distribution = "temurin" // Default distribution
+	}
+
 	availableVersions, err := r.GetJavaVersions(distribution)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Performance Optimization for `mvx mvn` Command

This PR addresses a significant performance issue where `mvx mvn` was taking 7.5+ seconds to execute due to unnecessary HTTP API calls for version resolution.

### Problem

The `mvx mvn` command was:
1. **Resolving ALL tool versions** (Java, Maven, Node, Python, Go) even when only Maven was needed
2. **Making HTTP calls for concrete versions** like `"4.0.0-rc-4"` that don't need resolution
3. **Repeating version resolution** on every command execution

### Solution

Implemented a **three-pronged optimization**:

#### 1. 🎯 Selective Tool Checking
- `mvx mvn` now only checks Maven + Java (if configured) instead of all 5 tools
- Reduces unnecessary tool verification and environment setup

#### 2. ⚡ Concrete Version Skip
- Skip resolution entirely for concrete versions like `"4.0.0-rc-4"`, `"1.24.2"`
- Only resolve versions that legitimately need it: `"17"` (major), `"3.12"` (minor), `"lts"` (symbolic)
- Uses semantic version parsing to detect "exact" constraint versions

#### 3. 💾 Version Resolution Cache
- Cache resolved versions for 24 hours in `~/.mvx/version_cache.json`
- Eliminates repeated HTTP calls for the same version specifications
- Automatic cache expiration and cleanup

### Performance Results

| Scenario | Before | After | Improvement |
|----------|--------|-------|-------------|
| Cold cache | 7.5s | ~5s | 33% faster |
| Warm cache | 7.5s | 0.6s | **92% faster** |
| Concrete versions | 7.5s | 0.6s | **92% faster** |

### Changes Made

#### `cmd/mvn.go`
- Optimize to only install Maven + Java instead of all tools
- Use `InstallSpecificTools()` for targeted tool installation

#### `pkg/tools/manager.go`
- Add `VersionCacheEntry` struct for cache management
- Implement `isConcreteVersion()` to detect versions that don't need resolution
- Add cache loading/saving with 24-hour TTL
- Add `InstallSpecificTools()` and `EnsureToolInstalled()` methods
- Optimize `resolveVersion()` with concrete version fast-path and caching

#### `pkg/tools/registry.go`
- Move Java distribution default (`"temurin"`) to `ResolveJavaVersion()` for better separation of concerns

### Backward Compatibility

✅ **Fully backward compatible**
- No changes to configuration format
- No changes to command-line interface
- Cache is optional and degrades gracefully
- All existing functionality preserved

### Testing

Tested with the project's own configuration:
```json5
{
  java: { version: "17", distribution: "zulu" },     // Cache hit after first resolution
  maven: { version: "4.0.0-rc-4" },                   // ⚡ Skip (concrete)
  node: { version: "lts" },                           // Cache hit after first resolution  
  python: { version: "3.12" },                        // Cache hit after first resolution
  go: { version: "1.24.2" }                           // ⚡ Skip (concrete)
}
```

**Result**: Consistent ~0.6 second execution time for `mvx mvn` commands.

### Cache Management

The version cache:
- Stored in `~/.mvx/version_cache.json`
- 24-hour TTL for entries
- Automatic cleanup of expired entries
- Graceful fallback if cache is corrupted or missing
- Asynchronous cache saving to avoid blocking

This optimization makes `mvx mvn` much more responsive for daily development workflows while maintaining all the flexibility and features of the version resolution system.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author