### PR TITLE
docs: fix hooks documentation to reflect actual implementation

### DIFF
--- a/website/content/commands.md
+++ b/website/content/commands.md
@@ -203,40 +203,36 @@ Set environment variables for commands:
 
 ## Command Hooks
 
-Run commands before or after built-in mvx commands:
+Add pre and post hooks to built-in mvx commands by defining them within the command configuration:
 
 ```json5
 {
-  hooks: {
-    "pre-setup": {
-      description: "Prepare environment before setup",
-      script: "echo 'Preparing environment...'"
-    },
-    "post-setup": {
-      description: "Verify installation after setup",
-      script: [
+  commands: {
+    // Add hooks to built-in 'setup' command
+    setup: {
+      description: "Setup with custom hooks",
+      pre: "echo 'Preparing environment...'",
+      post: [
         "echo 'Verifying tools...'",
         "./mvx tools verify java",
         "./mvx tools verify maven"
       ]
     },
-    "pre-build": {
-      description: "Pre-build checks",
-      script: "echo 'Running pre-build checks...'"
-    },
-    "post-build": {
-      description: "Post-build actions",
-      script: "echo 'Build completed successfully!'"
+
+    // Add hooks to built-in 'build' command
+    build: {
+      description: "Build with pre-checks",
+      pre: "echo 'Running pre-build checks...'",
+      post: "echo 'Build completed successfully!'"
     }
   }
 }
 ```
 
-Available hook points:
-- `pre-setup` / `post-setup`
-- `pre-build` / `post-build` (for custom build commands)
-- `pre-test` / `post-test` (for custom test commands)
-- `pre-clean` / `post-clean`
+Hook properties:
+- `pre` - Script to run before the built-in command
+- `post` - Script to run after the built-in command
+- Both support single strings or arrays of commands
 
 ## Command Overrides
 

--- a/website/content/configuration.md
+++ b/website/content/configuration.md
@@ -38,17 +38,7 @@ mvx uses a JSON5 configuration file (`.mvx/config.json5`) to define your project
     }
   },
   
-  // Command hooks (optional)
-  hooks: {
-    "pre-build": {
-      description: "Run before build",
-      script: "echo 'Starting build...'"
-    },
-    "post-build": {
-      description: "Run after build",
-      script: "echo 'Build completed!'"
-    }
-  }
+
 }
 ```
 
@@ -189,34 +179,38 @@ Define custom commands that become available as `./mvx <command>`:
 }
 ```
 
-## Hooks Section
+## Command Hooks
 
-Hooks allow you to run commands before or after built-in mvx commands:
+You can add pre and post hooks to built-in mvx commands by defining them within the command configuration:
 
 ```json5
 {
-  hooks: {
-    "pre-setup": {
-      description: "Prepare environment",
-      script: "echo 'Preparing environment...'"
+  commands: {
+    // Add hooks to the built-in 'build' command
+    build: {
+      description: "Build with custom hooks",
+      pre: "echo 'Starting build...'",
+      post: "echo 'Build completed!'"
     },
-    "post-setup": {
-      description: "Verify installation",
-      script: "echo 'Verifying tools...'"
-    },
-    "pre-build": {
-      description: "Pre-build checks",
-      script: "echo 'Running pre-build checks...'"
+
+    // Add hooks to the built-in 'test' command
+    test: {
+      description: "Test with verification",
+      pre: "echo 'Preparing test environment...'",
+      post: [
+        "echo 'Tests completed!'",
+        "echo 'Generating reports...'"
+      ]
     }
   }
 }
 ```
 
-Available hook points:
-- `pre-setup` / `post-setup`
-- `pre-build` / `post-build`
-- `pre-test` / `post-test`
-- `pre-clean` / `post-clean`
+Available hook points for built-in commands:
+- `build` - Build command hooks
+- `test` - Test command hooks
+- `setup` - Setup command hooks
+- `clean` - Clean command hooks
 
 ## Command Overrides
 


### PR DESCRIPTION
## Problem

The documentation incorrectly showed a separate `hooks` section in the configuration that is not implemented in the codebase. This created confusion as users would try to use the documented syntax but it wouldn't work.

## Analysis

After examining the code:
- The `Config` struct has no `hooks` field
- Only inline hooks are supported via `pre` and `post` properties within command configurations
- The executor only looks for hooks in the command's own `Pre` and `Post` fields

## Changes

- ✅ Remove misleading separate `hooks` section examples from `configuration.md` and `commands.md`
- ✅ Replace with correct documentation showing inline hooks within commands
- ✅ Update examples to show the actual supported syntax (`pre`/`post` properties)
- ✅ Clarify that hooks work with built-in commands only

## Testing

- [x] Verified the documented syntax matches the actual implementation in the codebase
- [x] Confirmed no other references to the unimplemented hooks section remain

## Follow-up

Created issue #19 to track implementing the external hooks section as a future enhancement, which would allow:
- Hook reuse across multiple commands
- Cleaner separation of concerns
- More maintainable configuration for complex projects