### PR TITLE
Fix argument parsing for mvx mvn to support Maven flags like -V

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,37 @@ Imagine cloning any project and running:
 ./mvx build    # Builds the project with the right environment
 ./mvx test     # Runs tests with proper configuration
 ./mvx demo     # Launches project-specific demos or examples
+
+# Or use tools directly with natural syntax
+./mvx mvn -V clean install    # Maven with version flag
+./mvx --verbose mvn -X test   # mvx verbose + Maven debug
 ```
 
 No more "works on my machine" - every developer gets the exact same environment.
+
+## 🔧 Maven Integration
+
+mvx provides seamless Maven integration with transparent argument passing:
+
+```bash
+# All Maven flags work naturally - no special syntax needed
+./mvx mvn -V                    # Show Maven version
+./mvx mvn -X clean install      # Debug mode with clean install
+./mvx mvn -Pproduction package  # Activate profile and package
+
+# Combine mvx global flags with Maven flags
+./mvx --verbose mvn -V          # mvx verbose output + Maven version
+./mvx --quiet mvn test          # mvx quiet mode + Maven test
+
+# Backward compatibility maintained
+./mvx mvn -- -V                 # Still works (with helpful migration warning)
+```
+
+**Key Benefits:**
+- **🎯 Natural syntax**: Use Maven flags exactly as you would with `mvn`
+- **🔄 Transparent wrapper**: mvx acts like `mvnw` but with enhanced tool management
+- **⚡ No learning curve**: Existing Maven knowledge applies directly
+- **🛡️ Backward compatible**: Existing scripts continue to work
 
 ## 📦 mvx Bootstrap
 

--- a/cmd/mvn.go
+++ b/cmd/mvn.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/gnodet/mvx/pkg/config"
 	"github.com/gnodet/mvx/pkg/tools"
@@ -13,15 +14,37 @@ import (
 
 // mvnCmd runs Maven with the environment provisioned by mvx
 var mvnCmd = &cobra.Command{
-	Use:   "mvn [args...]",
-	Short: "Run Apache Maven with mvx-managed environment",
+	Use:                "mvn [args...]",
+	Short:              "Run Apache Maven with mvx-managed environment",
+	DisableFlagParsing: true, // We handle parsing manually to support both mvx and Maven flags
 	Long: `Run Apache Maven using the version configured in .mvx/config.
+
+All arguments are passed directly to Maven without interpretation, allowing
+Maven flags like -V, -X, -P, etc. to work naturally.
 
 Examples:
   mvx mvn clean install
+  mvx mvn -V
+  mvx mvn -X clean compile
   mvx mvn -Plicense-check -N
   mvx mvn org.eclipse.tycho:tycho-versions-plugin:0.25.0:set-version ...`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Parse mvx global flags from os.Args and extract Maven arguments
+		mavenArgs, err := parseHybridArgs()
+		if err != nil {
+			return err
+		}
+
+
+
+		// Handle backward compatibility: remove '--' separator if present and warn
+		if len(mavenArgs) > 0 && mavenArgs[0] == "--" {
+			printWarning("The '--' separator is no longer needed with 'mvx mvn'. You can remove it for cleaner syntax.")
+			printWarning("  Before: mvx mvn -- %s", strings.Join(mavenArgs[1:], " "))
+			printWarning("  After:  mvx mvn %s", strings.Join(mavenArgs[1:], " "))
+			mavenArgs = mavenArgs[1:] // Remove the '--' separator
+		}
+
 		projectRoot, err := findProjectRoot()
 		if err != nil {
 			return fmt.Errorf("failed to find project root: %w", err)
@@ -73,7 +96,7 @@ Examples:
 			mvnExe += ".cmd"
 		}
 
-		c := exec.Command(mvnExe, args...)
+		c := exec.Command(mvnExe, mavenArgs...)
 		c.Dir = projectRoot
 		c.Env = env
 		c.Stdout = os.Stdout
@@ -81,6 +104,51 @@ Examples:
 		c.Stdin = os.Stdin
 		return c.Run()
 	},
+}
+
+// parseHybridArgs parses os.Args to extract mvx global flags and Maven arguments
+// This allows commands like: mvx --verbose mvn -V clean install
+func parseHybridArgs() ([]string, error) {
+	args := os.Args[1:] // Remove program name
+
+	// Find the "mvn" command position
+	mvnIndex := -1
+	for i, arg := range args {
+		if arg == "mvn" {
+			mvnIndex = i
+			break
+		}
+	}
+
+	if mvnIndex == -1 {
+		// This shouldn't happen since we're in the mvn command, but handle gracefully
+		return args, nil
+	}
+
+	// Extract mvx flags (everything before "mvn")
+	mvxFlags := args[:mvnIndex]
+
+	// Extract Maven arguments (everything after "mvn")
+	mavenArgs := args[mvnIndex+1:]
+
+	// Parse mvx global flags and set global variables
+	for i := 0; i < len(mvxFlags); i++ {
+		flag := mvxFlags[i]
+		switch flag {
+		case "--verbose", "-v":
+			verbose = true
+		case "--quiet", "-q":
+			quiet = true
+		case "--help", "-h":
+			// Let Cobra handle help
+			continue
+		default:
+			// Unknown mvx flag - this could be an error or we could ignore it
+			printWarning("Unknown mvx flag: %s (will be ignored)", flag)
+		}
+	}
+
+	return mavenArgs, nil
 }
 
 func init() { rootCmd.AddCommand(mvnCmd) }

--- a/website/content/commands.md
+++ b/website/content/commands.md
@@ -10,6 +10,33 @@ mvx provides both built-in commands for tool management and the ability to defin
 
 ## Built-in Commands
 
+### Tool Wrapper Commands
+
+mvx provides transparent wrapper commands for managed tools, allowing you to use them with their native syntax:
+
+#### Maven Integration
+
+```bash
+# Use Maven with natural syntax - all flags work
+./mvx mvn -V                    # Show Maven version
+./mvx mvn -X clean install      # Debug mode with clean install
+./mvx mvn -Pproduction package  # Activate profile and package
+./mvx mvn help:effective-pom    # Any Maven goal or plugin
+
+# Combine mvx global flags with Maven flags
+./mvx --verbose mvn -V          # mvx verbose output + Maven version
+./mvx --quiet mvn test          # mvx quiet mode + Maven test
+
+# Backward compatibility (with migration warnings)
+./mvx mvn -- -V                 # Still works, shows helpful migration tip
+```
+
+**Key Features:**
+- **🎯 Transparent wrapper**: Acts like `mvnw` but with enhanced tool management
+- **🔄 Natural syntax**: Use Maven flags exactly as you would with `mvn`
+- **⚡ No learning curve**: Existing Maven knowledge applies directly
+- **🛡️ Backward compatible**: Scripts using `--` separator continue to work
+
 ### Project Management
 
 ```bash
@@ -256,6 +283,72 @@ Override built-in mvx commands with custom implementations:
     }
   }
 }
+```
+
+## Maven Wrapper Integration
+
+mvx provides enhanced Maven wrapper functionality that goes beyond traditional `mvnw`:
+
+### Direct Maven Usage
+
+```bash
+# All Maven commands work naturally
+./mvx mvn clean install
+./mvx mvn -V                    # Show version
+./mvx mvn -X test              # Debug mode
+./mvx mvn -Pproduction package # Profile activation
+./mvx mvn help:effective-pom   # Plugin goals
+./mvx mvn dependency:tree      # Dependency analysis
+
+# Complex Maven commands work seamlessly
+./mvx mvn org.springframework.boot:spring-boot-maven-plugin:run
+./mvx mvn versions:set -DnewVersion=2.0.0
+```
+
+### Enhanced Features vs Traditional mvnw
+
+| Feature | Traditional `mvnw` | mvx Maven Integration |
+|---------|-------------------|----------------------|
+| Maven version management | ✅ Fixed version | ✅ Configurable version |
+| Java version management | ❌ System Java only | ✅ Automatic Java setup |
+| Tool isolation | ❌ Global tools | ✅ Project-specific tools |
+| Environment setup | ❌ Manual | ✅ Automatic |
+| Cross-platform | ✅ Yes | ✅ Enhanced |
+| Argument passing | ✅ Basic | ✅ Hybrid parsing |
+| Global flags | ❌ No | ✅ `--verbose`, `--quiet` |
+
+### Migration from mvnw
+
+Replace your existing Maven Wrapper with mvx:
+
+```bash
+# Before (traditional mvnw)
+./mvnw clean install
+./mvnw -V
+./mvnw spring-boot:run
+
+# After (mvx - same commands work)
+./mvx mvn clean install
+./mvx mvn -V
+./mvx mvn spring-boot:run
+
+# Plus enhanced capabilities
+./mvx --verbose mvn -X test     # mvx verbose + Maven debug
+./mvx setup                     # Auto-install Java + Maven
+```
+
+### Backward Compatibility
+
+Existing scripts using the `--` separator continue to work:
+
+```bash
+# Old syntax (still works with helpful warnings)
+./mvx mvn -- -V
+./mvx mvn -- clean install
+
+# New syntax (recommended)
+./mvx mvn -V
+./mvx mvn clean install
 ```
 
 ## Command Examples

--- a/website/content/configuration.md
+++ b/website/content/configuration.md
@@ -120,6 +120,92 @@ Enable checksum verification for enhanced security:
 }
 ```
 
+## Maven Integration
+
+mvx provides enhanced Maven wrapper functionality with transparent argument passing:
+
+### Direct Maven Usage
+
+You can use Maven directly through mvx without defining custom commands:
+
+```bash
+# All Maven commands work naturally
+./mvx mvn clean install
+./mvx mvn -V                    # Show version
+./mvx mvn -X test              # Debug mode
+./mvx mvn -Pproduction package # Profile activation
+
+# Combine mvx global flags with Maven flags
+./mvx --verbose mvn -V          # mvx verbose + Maven version
+./mvx --quiet mvn test          # mvx quiet mode + Maven test
+```
+
+### Maven Configuration Options
+
+```json5
+{
+  tools: {
+    maven: {
+      version: "3.9.6",                    // Maven version
+      settings: "custom-settings.xml",     // Custom settings file (optional)
+      checksum: {                          // Security verification (optional)
+        required: true                     // Fail on checksum errors
+      }
+    }
+  }
+}
+```
+
+### Maven vs Custom Commands
+
+You can use both approaches in the same project:
+
+```json5
+{
+  tools: {
+    maven: { version: "3.9.6" },
+    java: { version: "21" }
+  },
+  commands: {
+    // Custom commands for common workflows
+    build: {
+      description: "Standard build",
+      script: "mvn clean install"
+    },
+    "quick-build": {
+      description: "Build without tests",
+      script: "mvn clean install -DskipTests"
+    }
+  }
+}
+```
+
+**Usage:**
+```bash
+# Use custom commands for common workflows
+./mvx build
+./mvx quick-build
+
+# Use Maven directly for ad-hoc commands
+./mvx mvn dependency:tree
+./mvx mvn versions:display-updates
+./mvx mvn -Pintegration-tests verify
+```
+
+### Backward Compatibility
+
+Scripts using the `--` separator continue to work:
+
+```bash
+# Old syntax (still works with migration warnings)
+./mvx mvn -- -V
+./mvx mvn -- clean install
+
+# New syntax (recommended)
+./mvx mvn -V
+./mvx mvn clean install
+```
+
 ## Commands Section
 
 Define custom commands that become available as `./mvx <command>`:

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -105,6 +105,14 @@ Edit `.mvx/config.json5` to specify your project's requirements:
 ./mvx build
 ./mvx test
 
+# Use Maven directly with natural syntax
+./mvx mvn -V                    # Show Maven version
+./mvx mvn clean install         # Standard Maven build
+./mvx mvn -X test              # Debug mode testing
+
+# Combine mvx and Maven flags
+./mvx --verbose mvn -V          # mvx verbose + Maven version
+
 # Or use built-in commands
 ./mvx tools list
 ./mvx version
@@ -138,6 +146,23 @@ Edit `.mvx/config.json5` to specify your project's requirements:
     }
   }
 }
+```
+
+**Usage Examples:**
+```bash
+# Use custom commands
+./mvx build
+./mvx quick-build
+./mvx run
+
+# Or use Maven directly with natural syntax
+./mvx mvn -V                    # Show Maven version
+./mvx mvn clean install         # Standard build
+./mvx mvn -Pproduction package  # Production build with profile
+./mvx mvn spring-boot:run       # Run Spring Boot app
+
+# Combine mvx and Maven flags for debugging
+./mvx --verbose mvn -X test     # mvx verbose + Maven debug mode
 ```
 
 ### Secure Production Project

--- a/website/content/index.md
+++ b/website/content/index.md
@@ -52,6 +52,15 @@ layout: index
    </div>
 
    <div class="feature-card">
+       <div class="feature-icon">🔄</div>
+       <h3 class="feature-title">Enhanced Maven Wrapper</h3>
+       <p class="feature-description">
+           Drop-in replacement for <strong>Maven Wrapper (mvnw)</strong> with enhanced capabilities.
+           Natural Maven syntax, automatic Java setup, and transparent argument passing.
+       </p>
+   </div>
+
+   <div class="feature-card">
        <div class="feature-icon">⚡</div>
        <h3 class="feature-title">Simple Configuration</h3>
        <p class="feature-description">
@@ -94,7 +103,11 @@ layout: index
             <div class="quick-start-step">
                 <div class="step-number">4</div>
                 <h3>Build</h3>
-                <pre><code class="language-bash">./mvx setup && ./mvx build</code></pre>
+                <pre><code class="language-bash"># Setup tools and build
+./mvx setup && ./mvx build
+
+# Or use Maven directly
+./mvx mvn -V clean install</code></pre>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## 🎯 Overview

Resolves #11 by implementing enhanced argument parsing for the `mvx mvn` command that supports Maven flags like `-V`, `-X`, `-P` without requiring the `--` separator.

## 🔧 Technical Changes

### Enhanced Argument Parsing
- **Hybrid parsing implementation**: Supports both mvx global flags and Maven flags
- **DisableFlagParsing**: Added to `cmd/mvn.go` with custom argument handling
- **parseHybridArgs() function**: Extracts mvx flags before 'mvn' command and passes Maven arguments transparently
- **Natural Maven syntax**: All Maven flags now work exactly as expected

### Key Features
- ✅ **Maven flags work naturally**: `./mvx mvn -V`, `./mvx mvn -X clean install`
- ✅ **Combine mvx + Maven flags**: `./mvx --verbose mvn -V`
- ✅ **Backward compatibility**: `./mvx mvn -- -V` still works with helpful migration warnings
- ✅ **No breaking changes**: Existing scripts continue to work

## 🧪 Testing

Tested scenarios:
```bash
# Maven flags only (original issue - now fixed)
./mvx mvn -V                           ✅ Works
./mvx mvn -X clean install             ✅ Works  
./mvx mvn -Pprofile test               ✅ Works

# mvx global flags + Maven flags (new capability)
./mvx --verbose mvn -V                 ✅ Works
./mvx --quiet mvn -X test              ✅ Works

# Backward compatibility (with helpful warnings)
./mvx mvn -- -V                        ✅ Works + Warning
./mvx --verbose mvn -- -X clean        ✅ Works + Warning
```

## 📚 Documentation Updates

Comprehensive documentation updates across multiple files:

### README.md
- Added Maven integration section with transparent wrapper functionality
- Updated vision section with natural Maven syntax examples
- Added key benefits of enhanced argument parsing

### Website Documentation
- **commands.md**: Added comprehensive Maven wrapper integration section with comparison table
- **getting-started.md**: Updated examples to show both custom commands and direct Maven usage
- **configuration.md**: Added Maven integration configuration guide
- **index.md**: Added "Enhanced Maven Wrapper" feature card

## 🔄 Migration Path

### From Traditional Maven Wrapper
```bash
# Before (traditional mvnw)
./mvnw clean install
./mvnw -V

# After (mvx - same commands work)
./mvx mvn clean install
./mvx mvn -V

# Plus enhanced capabilities
./mvx --verbose mvn -X test     # mvx verbose + Maven debug
./mvx setup                     # Auto-install Java + Maven
```

### Backward Compatibility
```bash
# Old syntax (still works with helpful warnings)
./mvx mvn -- -V
./mvx mvn -- clean install

# New syntax (recommended)
./mvx mvn -V
./mvx mvn clean install
```

## 🎉 Benefits

- **🎯 Natural syntax**: Use Maven flags exactly as you would with `mvn`
- **🔄 Transparent wrapper**: Acts like `mvnw` but with enhanced tool management
- **⚡ No learning curve**: Existing Maven knowledge applies directly
- **🛡️ Backward compatible**: Existing scripts continue to work
- **🚀 Enhanced capabilities**: Automatic Java setup, tool isolation, environment management

## 📋 Files Changed

- `cmd/mvn.go`: Implemented hybrid argument parsing
- `README.md`: Added Maven integration documentation
- `website/content/commands.md`: Added comprehensive Maven wrapper section
- `website/content/getting-started.md`: Updated examples and usage patterns
- `website/content/configuration.md`: Added Maven integration configuration
- `website/content/index.md`: Added Enhanced Maven Wrapper feature

This enhancement makes mvx a true drop-in replacement for Maven Wrapper with additional capabilities for tool management and environment setup.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author