### PR TITLE
fix: standardize development binary naming and version handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ go.work
 dist/
 
 # Built binaries (but not wrapper scripts)
-mvx-binary
 mvx-dev
 /mvx-linux-*
 /mvx-darwin-*

--- a/.mvx/config.json5
+++ b/.mvx/config.json5
@@ -47,7 +47,7 @@
 
     build: {
       description: "Build mvx binary with platform-optimized settings",
-      script: "go build -o mvx-binary . && echo 'Installing global development binary...' && mkdir -p ~/.mvx/dev && cp mvx-binary ~/.mvx/dev/mvx && chmod +x ~/.mvx/dev/mvx && echo '✅ Global development binary installed at ~/.mvx/dev/mvx' && echo '   All projects using mvxVersion=dev will now use this binary automatically'",
+      script: "go build -o mvx-dev . && echo 'Installing global development binary...' && mkdir -p ~/.mvx/dev && cp mvx-dev ~/.mvx/dev/mvx && chmod +x ~/.mvx/dev/mvx && echo '✅ Global development binary installed at ~/.mvx/dev/mvx' && echo '   All projects using mvxVersion=dev will now use this binary automatically'",
       override: true
     },
 
@@ -96,13 +96,7 @@
 
     clean: {
       description: "Clean build artifacts",
-      script: "rm -f mvx-binary && rm -rf dist/ && rm -f ~/.mvx/dev/mvx && echo '🧹 Cleaned local and global dev binaries'",
-      override: true
-    },
-
-    clean: {
-      description: "Clean build artifacts",
-      script: "rm -f mvx-binary mvx-dev && rm -rf dist/ && rm -rf .mvx/local/ .mvx/tools/ .mvx/versions/",
+      script: "rm -f mvx-dev && rm -rf dist/ && rm -f ~/.mvx/dev/mvx && echo '🧹 Cleaned local and global dev binaries'",
       override: true
     }
   }

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ curl -fsSL https://raw.githubusercontent.com/gnodet/mvx/main/install-mvx.sh | ba
 **Install development version (latest features, may be unstable):**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/gnodet/mvx/main/install-mvx.sh | MVX_VERSION=main bash
+curl -fsSL https://raw.githubusercontent.com/gnodet/mvx/main/install-mvx.sh | MVX_VERSION=dev bash
 ```
 
 **Use mvx without global installation:**
@@ -110,7 +110,7 @@ curl -fsSL https://raw.githubusercontent.com/gnodet/mvx/main/install-mvx.sh | ba
 **Install development version:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/gnodet/mvx/main/install-mvx.sh | MVX_VERSION=main bash
+curl -fsSL https://raw.githubusercontent.com/gnodet/mvx/main/install-mvx.sh | MVX_VERSION=dev bash
 ```
 
 **Use mvx without global installation:**

--- a/install-mvx.sh
+++ b/install-mvx.sh
@@ -18,9 +18,9 @@ if [ -n "$REQUESTED_VERSION" ]; then
     echo "🔧 Using specified version: $REQUESTED_VERSION"
     BOOTSTRAP_VERSION="$REQUESTED_VERSION"
 
-    # If main branch is specified, use development version
-    if [ "$REQUESTED_VERSION" = "main" ]; then
-        echo "📦 Installing from main branch (development version)"
+    # If dev version is specified, use development version
+    if [ "$REQUESTED_VERSION" = "dev" ]; then
+        echo "📦 Installing development version"
     fi
 else
     # Get latest release version
@@ -28,8 +28,8 @@ else
     LATEST_RELEASE=$(curl -s https://api.github.com/repos/gnodet/mvx/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
     if [ -z "$LATEST_RELEASE" ]; then
-        echo "❌ Failed to get latest release, falling back to main branch"
-        BOOTSTRAP_VERSION="main"
+        echo "❌ Failed to get latest release, falling back to development version"
+        BOOTSTRAP_VERSION="dev"
     else
         echo "📦 Latest release: $LATEST_RELEASE"
         BOOTSTRAP_VERSION="$LATEST_RELEASE"
@@ -72,8 +72,8 @@ EOF
 fi
 
 # Update the version in the properties file to match the installed version
-if [ "$BOOTSTRAP_VERSION" = "main" ]; then
-    echo "📝 Setting version to 'dev' for main branch in mvx.properties"
+if [ "$BOOTSTRAP_VERSION" = "dev" ]; then
+    echo "📝 Setting version to 'dev' in mvx.properties"
     sed -i.bak "s/^mvxVersion=.*/mvxVersion=dev/" .mvx/mvx.properties && rm -f .mvx/mvx.properties.bak
 
     echo ""
@@ -109,8 +109,8 @@ echo "  3. Run './mvx update-bootstrap' to check for updates"
 echo "  4. Commit these files to your repository"
 echo ""
 echo "Advanced usage:"
-echo "  - Install development version: curl -fsSL ... | MVX_VERSION=main bash"
+echo "  - Install development version: curl -fsSL ... | MVX_VERSION=dev bash"
 echo "  - Install specific version: curl -fsSL ... | MVX_VERSION=v0.1.0 bash"
-echo "  - Or with command line argument: curl -fsSL ... | bash -s main"
+echo "  - Or with command line argument: curl -fsSL ... | bash -s dev"
 echo ""
 echo "For more information, see: https://github.com/gnodet/mvx/blob/main/BOOTSTRAP.md"

--- a/mvx
+++ b/mvx
@@ -346,7 +346,7 @@ find_mvx_binary() {
         echo "Error: Failed to download mvx binary from $download_url" >&2
 
         # Provide helpful guidance for development version
-        if [ "$version" = "dev" ] || [ "$version" = "main" ]; then
+        if [ "$version" = "dev" ]; then
             echo "" >&2
             echo "💡 You're using the development version, but no 'dev' binary is available." >&2
             echo "   To use mvx in development mode, you need to build it locally:" >&2
@@ -419,37 +419,37 @@ main() {
         echo "Requested version: $MVX_VERSION"
     fi
 
-    # Check for local binaries first, regardless of version
-    # This allows development version "dev" to work
+    # Check for local development binaries only when explicitly using dev version
+    if [ "$MVX_VERSION" = "dev" ]; then
+        # 1. Check project-specific development binary
+        local local_binaries="./mvx-dev"
+        if [ "$platform" = "windows-amd64" ]; then
+            local_binaries="./mvx-dev.exe"
+        fi
 
-    # 1. Check project-specific development binary
-    local local_binaries="./mvx-dev"
-    if [ "$platform" = "windows-amd64" ]; then
-        local_binaries="./mvx-dev.exe"
-    fi
+        for local_binary in $local_binaries; do
+            if [ -f "$local_binary" ] && [ -x "$local_binary" ]; then
+                if [ "$verbosity" = "verbose" ]; then
+                    echo "Using project-specific development binary: $local_binary"
+                    echo ""
+                fi
+                exec "$local_binary" "$@"
+            fi
+        done
 
-    for local_binary in $local_binaries; do
-        if [ -f "$local_binary" ] && [ -x "$local_binary" ]; then
+        # 2. Check global development binary (shared across all projects)
+        local global_dev_binary="$home_dir/.mvx/dev/mvx"
+        if [ "$platform" = "windows-amd64" ]; then
+            global_dev_binary="$home_dir/.mvx/dev/mvx.exe"
+        fi
+
+        if [ -f "$global_dev_binary" ] && [ -x "$global_dev_binary" ]; then
             if [ "$verbosity" = "verbose" ]; then
-                echo "Using project-specific development binary: $local_binary"
+                echo "Using global development binary: $global_dev_binary"
                 echo ""
             fi
-            exec "$local_binary" "$@"
+            exec "$global_dev_binary" "$@"
         fi
-    done
-
-    # 2. Check global development binary (shared across all projects)
-    local global_dev_binary="$home_dir/.mvx/dev/mvx"
-    if [ "$platform" = "windows-amd64" ]; then
-        global_dev_binary="$home_dir/.mvx/dev/mvx.exe"
-    fi
-
-    if [ -f "$global_dev_binary" ] && [ -x "$global_dev_binary" ]; then
-        if [ "$verbosity" = "verbose" ]; then
-            echo "Using global development binary: $global_dev_binary"
-            echo ""
-        fi
-        exec "$global_dev_binary" "$@"
     fi
 
     # No local binary found, proceed with version resolution and download

--- a/mvx.cmd
+++ b/mvx.cmd
@@ -65,25 +65,27 @@ if "%VERBOSITY%"=="verbose" (
     echo Requested version: %MVX_VERSION_TO_USE%
 )
 
-rem Check for local development binary first - always check regardless of version
-if exist ".\mvx-dev.exe" (
-    if "%VERBOSITY%"=="verbose" (
-        echo Using local development binary: .\mvx-dev.exe
-        echo.
+rem Check for local development binaries only when explicitly using dev version
+if "%MVX_VERSION_TO_USE%"=="dev" (
+    if exist ".\mvx-dev.exe" (
+        if "%VERBOSITY%"=="verbose" (
+            echo Using local development binary: .\mvx-dev.exe
+            echo.
+        )
+        ".\mvx-dev.exe" %*
+        goto :eof
     )
-    ".\mvx-dev.exe" %*
-    goto :eof
-)
 
-rem Check for global development binary (shared across all projects)
-set GLOBAL_DEV_BINARY=%HOME_DIR%\.mvx\dev\mvx.exe
-if exist "%GLOBAL_DEV_BINARY%" (
-    if "%VERBOSITY%"=="verbose" (
-        echo Using global development binary: %GLOBAL_DEV_BINARY%
-        echo.
+    rem Check for global development binary (shared across all projects)
+    set GLOBAL_DEV_BINARY=%HOME_DIR%\.mvx\dev\mvx.exe
+    if exist "%GLOBAL_DEV_BINARY%" (
+        if "%VERBOSITY%"=="verbose" (
+            echo Using global development binary: %GLOBAL_DEV_BINARY%
+            echo.
+        )
+        "%GLOBAL_DEV_BINARY%" %*
+        goto :eof
     )
-    "%GLOBAL_DEV_BINARY%" %*
-    goto :eof
 )
 
 rem Resolve version (handle "latest")


### PR DESCRIPTION
## Problem

The mvx bootstrap system had inconsistent naming and logic issues:

1. **Inconsistent binary naming**: Build script used `mvx-binary` while documentation referenced `mvx-dev`
2. **Incorrect version priority**: Development binaries were used regardless of configured version
3. **Confusing version identifiers**: Both `dev` and `main` were supported as development versions
4. **Bootstrap logic bug**: `mvxVersion=0.3.0` would still use development binary if available

## Solution

### 🔧 **Consistent Binary Naming**
- Standardized on `mvx-dev` for all development binaries
- Updated build script: `go build -o mvx-dev`
- Updated clean script and `.gitignore`
- Removed references to `mvx-binary`

### 🎯 **Fixed Version Priority Logic**
- Development binaries now only used when `mvxVersion=dev` is explicitly set
- `mvxVersion=0.3.0` correctly uses 0.3.0 release instead of dev binary
- Environment variable override still works: `MVX_VERSION=dev ./mvx`

### 🧹 **Simplified Version Identifiers**
- Removed support for `main` as development version
- Only `dev` is now recognized as development version
- Updated documentation and install script accordingly

## Testing

✅ **Version behavior verified**:
- `mvxVersion=0.3.0` → Uses 0.3.0 release
- `mvxVersion=dev` → Uses development binary
- `MVX_VERSION=dev ./mvx` → Environment override works
- `MVX_VERSION=main ./mvx` → Tries to download "main" release (fails as expected)

✅ **Binary naming consistent**:
- Build creates `mvx-dev`
- Bootstrap scripts look for `mvx-dev`
- Documentation references `mvx-dev`

## Files Changed

- **Bootstrap scripts** (`mvx`, `mvx.cmd`): Fixed version logic
- **Build config** (`.mvx/config.json5`): Use `mvx-dev` binary name
- **Install script** (`install-mvx.sh`): Remove `main` version support
- **Documentation** (`README.md`): Update examples to use `dev`
- **Git ignore** (`.gitignore`): Reflect correct binary name

This ensures consistent behavior across all platforms and eliminates confusion about when development binaries are used.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author