### PR TITLE
Fix archive type detection for Windows JDK downloads

### DIFF
--- a/pkg/tools/base_tool.go
+++ b/pkg/tools/base_tool.go
@@ -196,9 +196,14 @@ func (b *BaseTool) Download(url, version string, cfg config.ToolConfig) (string,
 		return "", fmt.Errorf("%s download failed: %s", strings.Title(b.toolName), DiagnoseDownloadError(url, err))
 	}
 
-	// Show user-friendly URL instead of long redirect URLs
+	// Show both the full URL and a user-friendly version for long redirect URLs
 	displayURL := getUserFriendlyURL(result.FinalURL)
-	fmt.Printf("  📦 Downloaded %d bytes from %s\n", result.Size, displayURL)
+	if displayURL != result.FinalURL {
+		fmt.Printf("  📦 Downloaded %d bytes from %s\n", result.Size, displayURL)
+		fmt.Printf("     Full URL: %s\n", result.FinalURL)
+	} else {
+		fmt.Printf("  📦 Downloaded %d bytes from %s\n", result.Size, result.FinalURL)
+	}
 
 	// Return the path to the downloaded file
 	return tmpFile.Name(), nil

--- a/pkg/tools/extraction.go
+++ b/pkg/tools/extraction.go
@@ -377,28 +377,69 @@ func extractTarXzFile(src, dest string) error {
 
 // detectArchiveType detects the archive type from file extension
 func detectArchiveType(filename string) string {
-	filename = strings.ToLower(filename)
+	lower := strings.ToLower(filename)
 
-	if strings.HasSuffix(filename, ".tar.gz") || strings.HasSuffix(filename, ".tgz") {
+	if strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tgz") {
 		return "tar.gz"
 	}
-	if strings.HasSuffix(filename, ".tar.xz") {
+	if strings.HasSuffix(lower, ".tar.xz") {
 		return "tar.xz"
 	}
-	if strings.HasSuffix(filename, ".zip") {
+	if strings.HasSuffix(lower, ".zip") {
 		return "zip"
 	}
-	if strings.HasSuffix(filename, ".gz") {
-		return "tar.gz" // Assume tar.gz for .gz files
+	if strings.HasSuffix(lower, ".gz") {
+		return "tar.gz"
 	}
 
-	// Default fallback
-	return "tar.gz"
+	return ""
 }
 
-// ExtractArchive extracts an archive file automatically detecting the type
+// detectArchiveTypeFromContent detects the archive type by reading magic bytes
+// from the file header. This is used as a fallback when the filename extension
+// is missing or ambiguous (e.g., temp files from redirected downloads).
+func detectArchiveTypeFromContent(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %w", err)
+	}
+	defer f.Close()
+
+	header := make([]byte, 6)
+	n, err := f.Read(header)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file header: %w", err)
+	}
+	header = header[:n]
+
+	if n >= 2 && header[0] == 0x50 && header[1] == 0x4b {
+		return "zip", nil
+	}
+	if n >= 2 && header[0] == 0x1f && header[1] == 0x8b {
+		return "tar.gz", nil
+	}
+	if n >= 6 && header[0] == 0xfd && header[1] == 0x37 && header[2] == 0x7a &&
+		header[3] == 0x58 && header[4] == 0x5a && header[5] == 0x00 {
+		return "tar.xz", nil
+	}
+
+	return "", fmt.Errorf("unrecognized archive format (magic bytes: %x)", header)
+}
+
+// ExtractArchive extracts an archive file automatically detecting the type.
+// It first tries extension-based detection, then falls back to reading magic
+// bytes from the file content. This handles cases where the file has a temp
+// name or the download URL was a redirect that lost the original extension.
 func ExtractArchive(src, dest string) error {
 	archiveType := detectArchiveType(src)
+	if archiveType == "" {
+		var err error
+		archiveType, err = detectArchiveTypeFromContent(src)
+		if err != nil {
+			return fmt.Errorf("unable to determine archive type for %s: %w", src, err)
+		}
+		util.LogVerbose("Detected archive type from content: %s", archiveType)
+	}
 
 	switch archiveType {
 	case "zip":

--- a/pkg/tools/extraction_test.go
+++ b/pkg/tools/extraction_test.go
@@ -1,0 +1,113 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectArchiveType(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		expected string
+	}{
+		{"tar.gz extension", "archive.tar.gz", "tar.gz"},
+		{"tgz extension", "archive.tgz", "tar.gz"},
+		{"tar.xz extension", "archive.tar.xz", "tar.xz"},
+		{"zip extension", "archive.zip", "zip"},
+		{"gz extension", "archive.gz", "tar.gz"},
+		{"uppercase ZIP", "Archive.ZIP", "zip"},
+		{"no extension", "archive", ""},
+		{"tmp extension", "mvx-download-12345.tmp", ""},
+		{"random extension", "file.dat", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := detectArchiveType(tc.filename)
+			if result != tc.expected {
+				t.Errorf("detectArchiveType(%q) = %q, want %q", tc.filename, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDetectArchiveTypeFromContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   []byte
+		expected string
+	}{
+		{"ZIP magic bytes", []byte{0x50, 0x4b, 0x03, 0x04, 0x00, 0x00}, "zip"},
+		{"GZIP magic bytes", []byte{0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00}, "tar.gz"},
+		{"XZ magic bytes", []byte{0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00}, "tar.xz"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.tmp")
+			if err := os.WriteFile(tmpFile, tc.header, 0644); err != nil {
+				t.Fatalf("Failed to create test file: %v", err)
+			}
+
+			result, err := detectArchiveTypeFromContent(tmpFile)
+			if err != nil {
+				t.Fatalf("detectArchiveTypeFromContent() returned error: %v", err)
+			}
+			if result != tc.expected {
+				t.Errorf("detectArchiveTypeFromContent() = %q, want %q", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDetectArchiveTypeFromContentUnrecognized(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.tmp")
+	if err := os.WriteFile(tmpFile, []byte("not an archive"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	_, err := detectArchiveTypeFromContent(tmpFile)
+	if err == nil {
+		t.Error("Expected error for unrecognized content, got nil")
+	}
+}
+
+func TestExtractArchiveFallsBackToContentDetection(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a minimal ZIP file with a .tmp extension (simulating a temp download)
+	// ZIP files start with PK (0x50 0x4b) magic bytes
+	// This is a minimal valid empty ZIP (end-of-central-directory record)
+	emptyZip := []byte{
+		0x50, 0x4b, 0x05, 0x06, // End of central directory signature
+		0x00, 0x00, // Number of this disk
+		0x00, 0x00, // Disk where central directory starts
+		0x00, 0x00, // Number of central directory records on this disk
+		0x00, 0x00, // Total number of central directory records
+		0x00, 0x00, 0x00, 0x00, // Size of central directory
+		0x00, 0x00, 0x00, 0x00, // Offset of start of central directory
+		0x00, 0x00, // Comment length
+	}
+
+	tmpFile := filepath.Join(tmpDir, "java-download-12345.tmp")
+	if err := os.WriteFile(tmpFile, emptyZip, 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	destDir := filepath.Join(tmpDir, "extracted")
+
+	// This should detect ZIP from magic bytes and extract successfully
+	err := ExtractArchive(tmpFile, destDir)
+	if err != nil {
+		t.Fatalf("ExtractArchive() with .tmp ZIP file failed: %v", err)
+	}
+
+	// Verify destination directory was created
+	if _, err := os.Stat(destDir); os.IsNotExist(err) {
+		t.Error("Destination directory was not created")
+	}
+}

--- a/pkg/tools/url_extension_test.go
+++ b/pkg/tools/url_extension_test.go
@@ -48,6 +48,16 @@ func TestURLExtensionDetection(t *testing.T) {
 			downloadURL: "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jdk_x64_linux_hotspot_22.0.2_9.tar.gz",
 			expectedExt: ".tar.gz",
 		},
+		{
+			name:        "Disco API redirect URL (no extension)",
+			downloadURL: "https://api.foojay.io/disco/v3.0/ids/abc123def456/redirect",
+			expectedExt: ".tar.gz",
+		},
+		{
+			name:        "URL with query parameters and .zip",
+			downloadURL: "https://example.com/download/tool-1.0.0.zip?token=abc123",
+			expectedExt: ".zip",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary
- Add content-based (magic bytes) archive type detection as a fallback when the filename extension is missing or ambiguous — fixes Windows JDK downloads where the redirect URL loses the `.zip` extension, causing mvx to incorrectly attempt gzip extraction
- Print the full download URL so users can see where files are being downloaded from
- Add unit tests for both extension-based and content-based archive detection

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./pkg/tools/... -run TestDetectArchive` — all pass
- [x] `go test ./pkg/tools/... -run TestExtractArchiveFallsBackToContentDetection` — verifies a `.tmp` file with ZIP magic bytes is correctly extracted as ZIP
- [x] `go test ./pkg/tools/... -run TestURLExtension` — all pass including new redirect URL cases
- [x] `go test ./pkg/...` — full package test suite passes

Fixes #66