### PR TITLE
Fix JDK download loop (#67)

### DIFF
--- a/pkg/tools/base_tool.go
+++ b/pkg/tools/base_tool.go
@@ -754,32 +754,8 @@ func (b *BaseTool) StandardIsInstalled(versionSpec string, cfg config.ToolConfig
 		return true
 	}
 
-	if resolveErr != nil {
-		return false
-	}
-
-	if targetVersion == "" {
-		util.LogVerbose("Resolved target version for %s %s is empty", b.toolName, versionSpec)
-		return false
-	}
-
-	installCfg := cfg
-	installCfg.Version = targetVersion
-
-	util.LogVerbose("%s version %s not installed, attempting automatic installation", b.toolName, targetVersion)
-	if err := tool.Install(targetVersion, installCfg); err != nil {
-		util.LogVerbose("Automatic installation of %s %s failed: %v", b.toolName, targetVersion, err)
-		return false
-	}
-
-	if err := tool.Verify(targetVersion, installCfg); err != nil {
-		util.LogVerbose("Verification after installing %s %s failed: %v", b.toolName, targetVersion, err)
-		return false
-	}
-
-	b.clearPathCache()
-	util.LogVerbose("Successfully installed %s %s on demand", b.toolName, targetVersion)
-	return true
+	util.LogVerbose("%s version %s is not installed", b.toolName, versionSpec)
+	return false
 }
 
 func (b *BaseTool) resolveTargetVersion(tool Tool, spec *version.Spec, versionSpec string, cfg config.ToolConfig) (string, error) {

--- a/pkg/tools/manager.go
+++ b/pkg/tools/manager.go
@@ -719,15 +719,10 @@ func (m *Manager) EnsureTool(toolName string, cfg config.ToolConfig) (string, er
 
 	// Check if installed
 	if !tool.IsInstalled(resolvedVersion, resolvedConfig) {
-		// Auto-install
+		// Auto-install (Install already verifies internally)
 		util.LogVerbose("Auto-installing %s %s...", toolName, resolvedVersion)
 		if err := tool.Install(resolvedVersion, resolvedConfig); err != nil {
 			return "", fmt.Errorf("failed to install %s %s: %w", toolName, resolvedVersion, err)
-		}
-
-		// Verify installation
-		if err := tool.Verify(resolvedVersion, resolvedConfig); err != nil {
-			return "", fmt.Errorf("failed to verify %s %s: %w", toolName, resolvedVersion, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Remove auto-install side effect from `StandardIsInstalled()` in `base_tool.go` — a check method was calling `tool.Install()` internally, downloading the JDK, then verifying with a config that had empty `Distribution` while the install directory was created under `temurin`. The verification looked in the wrong directory (`22.0.2` instead of `22.0.2@temurin`), returned false, and the caller re-downloaded.
- Remove redundant `Verify()` call from `EnsureTool()` in `manager.go` — all `Install` implementations already verify internally, and the external `Verify` used potentially wrong config (empty distribution).

## Root cause
`StandardIsInstalled()` violated command-query separation: a method named "IsInstalled" was triggering downloads and installations as a side effect. When the post-install verification failed due to a distribution config mismatch, it returned `false`, causing the caller (`GetToolsNeedingInstallation` → `EnsureTool`) to re-download.

## Test plan
- [x] `go build ./...` compiles successfully
- [x] All unit tests pass (`go test ./cmd/... ./pkg/... -count=1`)
- [x] Integration test timeout is pre-existing on `main`, unrelated to this change

Fixes #67